### PR TITLE
Using Authorization Code Grant instead of Client Credentials

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ app.get('/narrative/oauth/callback', function (req, res) {
       "Authorization": authString
     },
     formData: {
-      grant_type: "client_credentials", //authorization_code
+      grant_type: "authorization_code",
       code: req.session.narrative_oauth_code,
       redirect_uri: process.env.narrative_token_redirect_uri,
       client_id: process.env.narrative_client_id
@@ -69,7 +69,7 @@ app.get('/narrative/token/callback', function (req, res) {
   req.session.narrative_token = res.token;
 });
 
-app.listen(80, function () {});
+app.listen(3000, function () {});
 
 
 


### PR DESCRIPTION
Granting more appropriate permissions. This works locally for me, with a freshly created Oauth App: 

<img width="1203" alt="screen shot 2016-06-17 at 10 11 11" src="https://cloud.githubusercontent.com/assets/2642590/16144696/fd2e8a40-3474-11e6-8710-98d13a2b7d7c.png">

And with environment file looking as follows:

``` bash
session_secret= # omitted
narrative_client_id= # omitted
narrative_client_secret= # omitted
narrative_oauth_redirect_uri=http://localhost:3000/narrative/oauth/callback/
narrative_token_redirect_uri=http://localhost:3000/narrative/oauth/callback/
root_url=localhost:3000
```

This is running the server locally on port 3000 instead, without having to have superuser permissions for running the server.

Hope that this will work for you as well.
